### PR TITLE
Mvp support

### DIFF
--- a/generators/app/prompt.js
+++ b/generators/app/prompt.js
@@ -526,6 +526,7 @@ function creationMode(obj) {
       when: answers => {
          let result = util.isPaaS(answers, obj) && obj.options.azureSub === undefined && util.isVSTS(answers.tfs);
          let kube = answers.target === 'kubernetes';
+         console.log(result + ". " + kube);
          return result || kube;
       }
    };

--- a/generators/app/prompt.js
+++ b/generators/app/prompt.js
@@ -213,6 +213,19 @@ function target(obj) {
    };
 }
 
+function kubeTarget(obj) {
+   return {
+      name: `target`,
+      type: `list`,
+      store: true,
+      message: `Where would you like to deploy?`,
+      choices: util.getKubeTargets,
+      when: answers => {
+         return obj.options.target === undefined;
+      }
+   };
+}
+
 // Azure
 function azureSubInput(obj) {
    return {
@@ -544,6 +557,7 @@ module.exports = {
    profileCmd: profileCmd,
    dockerHost: dockerHost,
    tfsVersion: tfsVersion,
+   kubeTarget: kubeTarget,
    profileName: profileName,
    dockerPorts: dockerPorts,
    azureSubList: azureSubList,

--- a/generators/app/prompt.js
+++ b/generators/app/prompt.js
@@ -525,9 +525,8 @@ function creationMode(obj) {
       ],
       when: answers => {
          let result = util.isPaaS(answers, obj) && obj.options.azureSub === undefined && util.isVSTS(answers.tfs);
-         let kube = answers.target === 'kubernetes';
-         console.log(result + ". " + kube);
-         return result || kube;
+
+         return result;
       }
    };
 }

--- a/generators/app/prompt.js
+++ b/generators/app/prompt.js
@@ -151,6 +151,34 @@ function queue(obj) {
    };
 }
 
+function kubeQueue(obj) {
+   return {
+      store: true,
+      type: `list`,
+      name: `queue`,
+      default: `Default`,
+      choices: [{
+         name: `Default`,
+         value: `Default`
+      },
+      {
+         name: `Hosted Linux Preview`,
+         value: `Hosted Linux Preview`
+      }
+   ],
+      message: `What agent queue would you like to use?`,
+      when: answers => {
+         var result = obj.options.queue === undefined;
+
+         if (result) {
+            obj.log(`  Getting Agent Queues...`);
+         }
+
+         return result;
+      }
+   };
+}
+
 function applicationType(obj) {
    return {
       name: `type`,
@@ -552,6 +580,7 @@ module.exports = {
    groupId: groupId,
    tenantId: tenantId,
    gitAction: gitAction,
+   kubeQueue: kubeQueue,
    installDep: installDep,
    azureSubId: azureSubId,
    profileCmd: profileCmd,
@@ -568,12 +597,12 @@ module.exports = {
    dockerCertPath: dockerCertPath,
    applicationType: applicationType,
    applicationName: applicationName,
+   kubeEndpointList: kubeEndpointList,
+   imagePullSecrets: imagePullSecrets,
+   azureRegistryName: azureRegistryName,
    servicePrincipalId: servicePrincipalId,
    servicePrincipalKey: servicePrincipalKey,
    dockerRegistryPassword: dockerRegistryPassword,
    dockerRegistryUsername: dockerRegistryUsername,
-   kubeEndpointList: kubeEndpointList,
-   azureRegistryName: azureRegistryName,
-   azureRegistryResourceGroup: azureRegistryResourceGroup,
-   imagePullSecrets: imagePullSecrets
+   azureRegistryResourceGroup: azureRegistryResourceGroup
 };

--- a/generators/app/utility.js
+++ b/generators/app/utility.js
@@ -97,14 +97,6 @@ function getTargets(answers) {
             name: `Both`,
             value: `dockerpaas`
          }];
-      } else if (answers.type === 'kubernetes') {
-         targets = [{
-            name: 'Kubernetes: Azure Kubernetes Service',
-            value: 'aks'
-         }, {
-            name: 'Kubernetes: Azure Container Services',
-            value: 'acs'
-         }];
       } else if (answers.type === `aspFull`) {
          targets = [{
             name: `Azure App Service`,
@@ -129,12 +121,6 @@ function getTargets(answers) {
          }, {
             name: `Docker Host`,
             value: `docker`
-         }, {
-            name: 'Kubernetes: Azure Kubernetes Service',
-            value: 'aks'
-         }, {
-            name: 'Kubernetes: Azure Container Services',
-            value: 'acs'
          }];
 
          // TODO: Investigate if we need to remove these
@@ -154,6 +140,23 @@ function getTargets(answers) {
    });
 }
 
+function getKubeTargets(answers) {
+   return new Promise(function (resolve, reject) {
+
+      let targets = [];
+
+      targets = [{
+         name: 'Kubernetes: Azure Kubernetes Service',
+         value: 'aks'
+      }, {
+         name: 'Kubernetes: Azure Container Services',
+         value: 'acs'
+      }];
+
+      resolve(targets);
+   });
+}
+
 function getAppTypes(answers) {
    // Default to languages that work on all agents
    let types = [{
@@ -165,9 +168,6 @@ function getAppTypes(answers) {
    }, {
       name: `Java`,
       value: `java`
-   }, {
-      name: 'Kubernetes: Default (nginx)',
-      value: 'kubernetes'
    }
       // , {
       //    name: `Custom`,
@@ -1339,6 +1339,7 @@ module.exports = {
    reconcileValue: reconcileValue,
    searchProfiles: searchProfiles,
    tryFindProject: tryFindProject,
+   getKubeTargets: getKubeTargets,
    validateGroupID: validateGroupID,
    extractInstance: extractInstance,
    needsDockerHost: needsDockerHost,

--- a/generators/k8helmpipeline/app.js
+++ b/generators/k8helmpipeline/app.js
@@ -214,9 +214,9 @@ module.exports = {
 
    // Exports the portions of the file we want to share with files that require 
    // it.
-   acsExtensionsCheck: acsExtensionsCheck,
-   acsExtensionsCheckOrInstall: acsExtensionsCheckOrInstall,
-   acsExtensionsInstall: acsExtensionsInstall,
    createArm: createArm, 
-   getKubeInfo: getKubeInfo
+   getKubeInfo: getKubeInfo,
+   acsExtensionsCheck: acsExtensionsCheck,
+   acsExtensionsInstall: acsExtensionsInstall,
+   acsExtensionsCheckOrInstall: acsExtensionsCheckOrInstall
 };

--- a/generators/k8helmpipeline/index.js
+++ b/generators/k8helmpipeline/index.js
@@ -28,7 +28,6 @@ module.exports = class extends Generator {
       argUtils.servicePrincipalId(this);
       argUtils.servicePrincipalKey(this);
       argUtils.pat(this);
-      argUtils.customFolder(this);
       argUtils.azureRegistryName(this);
       argUtils.azureRegistryResourceGroup(this);
       argUtils.imagePullSecrets(this);
@@ -47,7 +46,6 @@ module.exports = class extends Generator {
          prompts.pat(this),
          prompts.kubeQueue(this),
          prompts.applicationName(this),
-         prompts.customFolder(this),
          prompts.kubeTarget(this),
          prompts.kubeEndpointList(this),
          prompts.azureSubList(this),
@@ -70,7 +68,6 @@ module.exports = class extends Generator {
          this.azureSubId = util.reconcileValue(cmdLnInput.options.azureSubId, answers.azureSubId, ``);
          this.azureRegistryName = util.reconcileValue(cmdLnInput.option.azureRegistryName, answers.azureRegistryName, ``);
          this.azureRegistryResourceGroup = util.reconcileValue(cmdLnInput.options.azureRegistryResourceGroup, answers.azureRegistryResourceGroup, ``);
-         this.customFolder = util.reconcileValue(cmdLnInput.options.customFolder, answers.customFolder, ``);
          this.applicationName = util.reconcileValue(cmdLnInput.options.applicationName, answers.applicationName, ``);
          this.servicePrincipalId = util.reconcileValue(cmdLnInput.options.servicePrincipalId, answers.servicePrincipalId, ``);
          this.servicePrincipalKey = util.reconcileValue(cmdLnInput.options.servicePrincipalKey, answers.servicePrincipalKey, ``);

--- a/generators/k8helmpipeline/index.js
+++ b/generators/k8helmpipeline/index.js
@@ -25,8 +25,6 @@ module.exports = class extends Generator {
       argUtils.azureSubId(this);
       argUtils.kubeEndpoint(this);
       argUtils.tenantId(this);
-      argUtils.servicePrincipalId(this);
-      argUtils.servicePrincipalKey(this);
       argUtils.pat(this);
       argUtils.azureRegistryName(this);
       argUtils.azureRegistryResourceGroup(this);
@@ -63,7 +61,7 @@ module.exports = class extends Generator {
          this.target = util.reconcileValue(cmdLnInput.options.target, answers.target);
          this.azureSub = util.reconcileValue(cmdLnInput.options.azureSub, answers.azureSub, ``);
          this.kubeEndpoint = util.reconcileValue(cmdLnInput.option.kubeEndpoint, answers.kubeEndpoint, ``);
-         this.tenantId = util.reconcileValue(cmdLnInput.options.tenantId, answers.tenantId, ``);
+         this.tenantId = util.reconcileValue(cmdLnInput.options.tenantId, ``, ``);
          this.azureSubId = util.reconcileValue(cmdLnInput.options.azureSubId, answers.azureSubId, ``);
          this.azureRegistryName = util.reconcileValue(cmdLnInput.option.azureRegistryName, answers.azureRegistryName, ``);
          this.azureRegistryResourceGroup = util.reconcileValue(cmdLnInput.options.azureRegistryResourceGroup, answers.azureRegistryResourceGroup, ``);

--- a/generators/k8helmpipeline/index.js
+++ b/generators/k8helmpipeline/index.js
@@ -45,7 +45,7 @@ module.exports = class extends Generator {
       return this.prompt([
          prompts.tfs(this),
          prompts.pat(this),
-         prompts.queue(this),
+         prompts.kubeQueue(this),
          prompts.applicationName(this),
          prompts.customFolder(this),
          prompts.kubeTarget(this),

--- a/generators/k8helmpipeline/index.js
+++ b/generators/k8helmpipeline/index.js
@@ -40,15 +40,15 @@ module.exports = class extends Generator {
       // This gives me access to the generator in the
       // when callbacks of prompt
       let cmdLnInput = this;
+      cmdLnInput.options.type = 'kubernetes';
 
       return this.prompt([
          prompts.tfs(this),
          prompts.pat(this),
          prompts.queue(this),
-         prompts.applicationType(this),
          prompts.applicationName(this),
          prompts.customFolder(this),
-         prompts.target(this),
+         prompts.kubeTarget(this),
          prompts.kubeEndpointList(this),
          prompts.azureSubList(this),
          prompts.creationMode(this),
@@ -61,7 +61,7 @@ module.exports = class extends Generator {
          // of the generator
          this.pat = util.reconcileValue(cmdLnInput.options.pat, answers.pat);
          this.tfs = util.reconcileValue(cmdLnInput.options.tfs, answers.tfs);
-         this.type = util.reconcileValue(cmdLnInput.options.type, answers.type);
+         this.type = util.reconcileValue(cmdLnInput.options.type, ``,``);
          this.queue = util.reconcileValue(cmdLnInput.options.queue, answers.queue);
          this.target = util.reconcileValue(cmdLnInput.options.target, answers.target);
          this.azureSub = util.reconcileValue(cmdLnInput.options.azureSub, answers.azureSub, ``);

--- a/generators/k8helmpipeline/index.js
+++ b/generators/k8helmpipeline/index.js
@@ -49,7 +49,6 @@ module.exports = class extends Generator {
          prompts.kubeTarget(this),
          prompts.kubeEndpointList(this),
          prompts.azureSubList(this),
-         prompts.creationMode(this),
          prompts.azureRegistryName(this),
          prompts.azureRegistryResourceGroup(this),
          prompts.imagePullSecrets(this)
@@ -69,8 +68,6 @@ module.exports = class extends Generator {
          this.azureRegistryName = util.reconcileValue(cmdLnInput.option.azureRegistryName, answers.azureRegistryName, ``);
          this.azureRegistryResourceGroup = util.reconcileValue(cmdLnInput.options.azureRegistryResourceGroup, answers.azureRegistryResourceGroup, ``);
          this.applicationName = util.reconcileValue(cmdLnInput.options.applicationName, answers.applicationName, ``);
-         this.servicePrincipalId = util.reconcileValue(cmdLnInput.options.servicePrincipalId, answers.servicePrincipalId, ``);
-         this.servicePrincipalKey = util.reconcileValue(cmdLnInput.options.servicePrincipalKey, answers.servicePrincipalKey, ``);
          this.imagePullSecrets = util.reconcileValue(cmdLnInput.options.imagePullSecrets, answers.imagePullSecrets, ``);
       }.bind(this));
    }

--- a/generators/k8helmpipeline/index.js
+++ b/generators/k8helmpipeline/index.js
@@ -68,7 +68,7 @@ module.exports = class extends Generator {
 
    // 5. Where you write the generator specific files (routes, controllers, etc)
    writing() {
-      let acrServer = this.azureRegistryName + ".azurecr.io";
+      let acrServer = this.azureRegistryName.toLowerCase() + ".azurecr.io";
       let appName = this.applicationName;
 
       var tokens = {

--- a/generators/k8helmpipeline/index.js
+++ b/generators/k8helmpipeline/index.js
@@ -16,7 +16,6 @@ module.exports = class extends Generator {
       // Order is important
       // These are position based arguments for this generator. If they are not provided
       // via the command line they will be queried during the prompting priority
-      argUtils.applicationType(this);
       argUtils.applicationName(this);
       argUtils.tfs(this);
       argUtils.queue(this);
@@ -27,6 +26,9 @@ module.exports = class extends Generator {
       argUtils.azureRegistryName(this);
       argUtils.azureRegistryResourceGroup(this);
       argUtils.imagePullSecrets(this);
+
+      // If user is running this sub-generator, they are deploying to Kubernetes
+      this.type = 'kubernetes';
    }
 
    // 2. Where you prompt users for options (where you'd call this.prompt())
@@ -35,7 +37,6 @@ module.exports = class extends Generator {
       // This gives me access to the generator in the
       // when callbacks of prompt
       let cmdLnInput = this;
-      cmdLnInput.options.type = 'kubernetes';
 
       return this.prompt([
          prompts.tfs(this),
@@ -54,7 +55,6 @@ module.exports = class extends Generator {
          // of the generator
          this.pat = util.reconcileValue(cmdLnInput.options.pat, answers.pat);
          this.tfs = util.reconcileValue(cmdLnInput.options.tfs, answers.tfs);
-         this.type = util.reconcileValue(cmdLnInput.options.type, ``,``);
          this.queue = util.reconcileValue(cmdLnInput.options.queue, answers.queue);
          this.target = util.reconcileValue(cmdLnInput.options.target, answers.target);
          this.azureSub = util.reconcileValue(cmdLnInput.options.azureSub, answers.azureSub, ``);

--- a/generators/k8helmpipeline/index.js
+++ b/generators/k8helmpipeline/index.js
@@ -22,9 +22,7 @@ module.exports = class extends Generator {
       argUtils.queue(this);
       argUtils.target(this);
       argUtils.azureSub(this);
-      argUtils.azureSubId(this);
       argUtils.kubeEndpoint(this);
-      argUtils.tenantId(this);
       argUtils.pat(this);
       argUtils.azureRegistryName(this);
       argUtils.azureRegistryResourceGroup(this);
@@ -61,8 +59,6 @@ module.exports = class extends Generator {
          this.target = util.reconcileValue(cmdLnInput.options.target, answers.target);
          this.azureSub = util.reconcileValue(cmdLnInput.options.azureSub, answers.azureSub, ``);
          this.kubeEndpoint = util.reconcileValue(cmdLnInput.option.kubeEndpoint, answers.kubeEndpoint, ``);
-         this.tenantId = util.reconcileValue(cmdLnInput.options.tenantId, ``, ``);
-         this.azureSubId = util.reconcileValue(cmdLnInput.options.azureSubId, answers.azureSubId, ``);
          this.azureRegistryName = util.reconcileValue(cmdLnInput.option.azureRegistryName, answers.azureRegistryName, ``);
          this.azureRegistryResourceGroup = util.reconcileValue(cmdLnInput.options.azureRegistryResourceGroup, answers.azureRegistryResourceGroup, ``);
          this.applicationName = util.reconcileValue(cmdLnInput.options.applicationName, answers.applicationName, ``);

--- a/unit/test/k8HelmTests.js
+++ b/unit/test/k8HelmTests.js
@@ -23,7 +23,6 @@ describe(`k8helmpipeline:index`, function() {
       let type = `kubernetes`;
       let pat = `token`;
       let target = `acs`;
-      let customFolder = ` `;
       let queue = `Hosted Linux Queue`;
       let azureSub = `AzureSub`;
       let tenantId = `TenantId`;
@@ -33,7 +32,6 @@ describe(`k8helmpipeline:index`, function() {
       let servicePrincipalKey = `servicePrincipalKey`;
       let tfs = `http://localhost:8080/tfs/DefaultCollection`;
       let kubeEndpointList = `Default`;
-      let creationMode = `Automatic`;
       let endpointId = "12345";
       let kubeEndpoint = "12345";
       let azureRegistryName = "RegistryName";
@@ -60,10 +58,11 @@ describe(`k8helmpipeline:index`, function() {
 
       return helpers.run(path.join(__dirname, `../../generators/k8helmpipeline`))
          .withGenerators(deps)
-         .withArguments([type, applicationName, tfs, queue, target, azureSub, azureSubId, kubeEndpointList,
-            tenantId, servicePrincipalId, servicePrincipalKey, pat, customFolder, azureRegistryName, azureRegistryResourceGroup, imagePullSecrets
+         .withArguments([type, applicationName, tfs, queue, target, azureSub, kubeEndpointList,
+            pat, azureRegistryName, azureRegistryResourceGroup, imagePullSecrets
          ])
          .on(`error`, function (e) {
+            assert.equal(sinon.stub(kubernetes, 'getKubeInfo').called, false);
             cleanUp();
             assert.fail(e);
          })
@@ -96,7 +95,7 @@ describe(`k8helmpipeline:index`, function() {
                });
             });
            
-            sinon.stub(build, 'run').callsFake(function(args, _this, done){
+            sinon.stub(build, 'run').callsFake(function(args, _this, done) {
                done();
             });
             sinon.stub(util, `findProject`).callsArgWith(4, null, {
@@ -164,8 +163,8 @@ describe(`k8helmpipeline:index`, function() {
 
       return helpers.run(path.join(__dirname, `../../generators/k8helmpipeline`))
          .withGenerators(deps)
-         .withArguments([type, applicationName, tfs, queue, target, azureSub, azureSubId, kubeEndpointList,
-            tenantId, servicePrincipalId
+         .withArguments([type, applicationName, tfs, queue, target, azureSub, kubeEndpointList,
+            pat, azureRegistryName, azureRegistryResourceGroup, imagePullSecrets
          ])
          .on(`error`, function (e) {
             assert.fail(e);

--- a/unit/test/utilityTests.js
+++ b/unit/test/utilityTests.js
@@ -12,9 +12,7 @@ assert.linuxTargets = function (a) {
    assert.equal(a[0].name, `Azure Container Instances (Linux)`);
    assert.equal(a[1].name, `Azure App Service Docker (Linux)`);
    assert.equal(a[2].name, `Docker Host`);
-   assert.equal(a[3].name, `Kubernetes: Azure Kubernetes Service`);
-   assert.equal(a[4].name, `Kubernetes: Azure Container Services`);
-   assert.equal(a.length, 5, `Wrong number of entries`);
+   assert.equal(a.length, 3, `Wrong number of entries`);
 };
 
 assert.allTargets = function (a) {
@@ -23,9 +21,7 @@ assert.allTargets = function (a) {
    assert.equal(a[2].name, `Azure Container Instances (Linux)`);
    assert.equal(a[3].name, `Azure App Service Docker (Linux)`);
    assert.equal(a[4].name, `Docker Host`);
-   assert.equal(a[5].name, `Kubernetes: Azure Kubernetes Service`);
-   assert.equal(a[6].name, `Kubernetes: Azure Container Services`);
-   assert.equal(a.length, 7, `Wrong number of entries`);
+   assert.equal(a.length, 5, `Wrong number of entries`);
 };
 
 assert.customTargets = function (a) {
@@ -660,7 +656,7 @@ describe(`utility`, function () {
          });
       });
 
-      it(`getTargets Default queue, default app type`, function (done) {
+      it(`getKubeTargets Default queue, default app type`, function (done) {
          // Arrange
          let answers = {
             queue: `Default`,
@@ -670,7 +666,7 @@ describe(`utility`, function () {
          };
 
          // Act
-         util.getTargets(answers).then(function (actual) {
+         util.getKubeTargets(answers).then(function (actual) {
             // Assert
             assert.kubernetesTargets(actual);
             done();
@@ -823,7 +819,7 @@ describe(`utility`, function () {
       let actual = util.getAppTypes(answers);
 
       // Assert
-      assert.equal(4, actual.length, `Wrong number of items returned`);
+      assert.equal(3, actual.length, `Wrong number of items returned`);
    });
 
    it(`getAppTypes macOS`, function () {
@@ -837,7 +833,7 @@ describe(`utility`, function () {
       let actual = util.getAppTypes(answers);
 
       // Assert
-      assert.equal(4, actual.length, `Wrong number of items returned`);
+      assert.equal(3, actual.length, `Wrong number of items returned`);
    });
 
    it(`getAppTypes default`, function () {
@@ -851,7 +847,7 @@ describe(`utility`, function () {
       let actual = util.getAppTypes(answers);
 
       // Assert
-      assert.equal(5, actual.length, `Wrong number of items returned`);
+      assert.equal(4, actual.length, `Wrong number of items returned`);
    });
 
    it(`addUserAgent`, function () {


### PR DESCRIPTION
Only included CLI options that are currently supported. For example, automatically chooses "kubernetes" as the application type because other applications aren't supported. Added new queue function because only Default and Hosted Linux Preview build agents work. 

Fixed Unit tests to support these changes. 